### PR TITLE
fix: Jitpack build by forcing JDK 11

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Then add the dependency in your app/build.gradle:
 
 ```groovy
 dependencies {
-	implementation 'com.github.markusfisch:BarcodeScannerView:1.5.0'
+	implementation 'com.github.markusfisch:BarcodeScannerView:1.5.1'
 }
 ```
 

--- a/barcodescannerview/build.gradle
+++ b/barcodescannerview/build.gradle
@@ -21,7 +21,7 @@ android {
 		targetSdkVersion sdk_version
 
 		versionCode 30
-		versionName '1.5.0'
+		versionName '1.5.1'
 	}
 
 	dependencies {
@@ -37,7 +37,7 @@ afterEvaluate {
 				from components.release
 				groupId = 'com.github.markusfisch'
 				artifactId = 'barcodescannerview'
-				version = '1.5.0'
+				version = '1.5.1'
 			}
 		}
 	}

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+jdk:
+  - openjdk11


### PR DESCRIPTION
This fixes the broken Jitpack builds by forcing it to use JDK 11 (my fork works as can be seen here: https://jitpack.io/com/github/1fexd/BarcodeScannerView/1.5.1/build.log)